### PR TITLE
Bump the GitHub actions to the latest version, etc

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "gradle"
+    directory: "/example"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,23 +14,25 @@ jobs:
       matrix:
         java_version: [ 8, 11, 17, 21 ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.java_version }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: ${{ matrix.java_version }}
-    - name: Setup and execute Gradle 'check' task
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: check
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+
+    - name: Run checks
+      run: ./gradlew check
     - name: Upload Gradle test reports
-      uses: actions/upload-artifact@v3
+      if: always()
+      uses: actions/upload-artifact@v7
       with:
-        name: gradle_test_reports
+        name: gradle_test_reports_java_${{ matrix.java_version }}
         path: build/reports/tests/test
     - name: Test `example` project with Chaos Dukey and confirm it fails
-      if: ${{ matrix.java_project == 21 }}
+      if: ${{ matrix.java_version == 21 }}
       env:
         CHAOS_DUKEY_ENABLED: true
       run: |
@@ -40,7 +42,7 @@ jobs:
         ! ./gradlew test &&
         grep 'expected: &lt;250&gt; but was: &lt;300&gt;' build/reports/tests/test/classes/org.komamitsu.example.jobqueue.JobQueueTest.html
     - name: Test `example` project without Chaos Dukey and confirm it succeeds
-      if: ${{ matrix.java_project == 21 }}
+      if: ${{ matrix.java_version == 21 }}
       run: |
         cd example &&
         ./gradlew test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: 8

--- a/example/chaos-dukey-100-percent.properties
+++ b/example/chaos-dukey-100-percent.properties
@@ -1,5 +1,5 @@
 delay.typeNamePattern=^org\.komamitsu\.example\.db\.account\.AccountDb$
 delay.methodNamePattern=^incrementBalance$
-delay.waitMode=RANDOM
-delay.percentage=1
+delay.waitMode=FIXED
+delay.percentage=100
 delay.maxDelayMillis=5000


### PR DESCRIPTION
## Overview
This pull request updates the CI workflow configuration in `.github/workflows/ci.yml` to use the latest versions of several GitHub Actions and fixes a typo in the matrix variable name. These changes ensure compatibility with newer action versions and correct the conditional logic for running certain jobs.

**CI workflow modernization and fixes:**

* Updated all GitHub Actions used in the workflow to their latest major versions (`actions/checkout@v4`, `actions/setup-java@v4`, `gradle/actions/setup-gradle@v4`, `actions/upload-artifact@v4`) to ensure continued support and access to new features.
* Fixed a typo in the conditional for running tests with Java 21 by changing `matrix.java_project` to `matrix.java_version`, ensuring the correct jobs are executed. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-R33) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL43-R43)

----

I noticed that the following two GitHub actions should be replaced with [softprops/action-gh-release](https://github.com/softprops/action-gh-release). However, I skipped it since I couldn't test that change with my permission. 
- https://github.com/actions/create-release
- https://github.com/actions/upload-release-asset